### PR TITLE
Workaround new git versions issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,6 +90,9 @@ ansible::lint() {
   local opts
   opts=$(parse_args $@ || exit 1)
 
+  # Workaround https://github.com/actions/runner-images/issues/6775
+  git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
   # Enable recursive glob patterns, such as '**/*.yml'.
   shopt -s globstar
   ansible-lint -v --force-color $opts ${TARGETS}


### PR DESCRIPTION
In new git versions git actions will fail if there is a mismatch between files and root dir permissions:
https://github.com/actions/runner-images/issues/6775
This is a workaround that will set the workdir as a safedir to ignore permissions mismatches